### PR TITLE
feat(react): add `useProperties` hook for multiple properties

### DIFF
--- a/packages/react/src/use-properties.spec.tsx
+++ b/packages/react/src/use-properties.spec.tsx
@@ -1,0 +1,31 @@
+import { Property, Env, clock, atom, property } from '@frp-ts/core'
+import React from 'react'
+import { useProperties } from './use-properties'
+import { constVoid } from '@frp-ts/utils'
+import { render } from '@testing-library/react'
+
+interface TestProps<Properties extends readonly Property<unknown>[]> {
+	readonly properties: Properties
+	readonly onValue: (...properties: property.MapPropertiesToValues<Properties>) => void
+}
+function Test<Properties extends readonly Property<unknown>[]>(props: TestProps<Properties>) {
+	props.onValue(...useProperties(...props.properties))
+	return <></>
+}
+
+const e: Env = {
+	clock: clock.newCounterClock(),
+}
+const newAtom = atom.newAtom(e)
+
+describe('useProperties', () => {
+	it('returns initial value', () => {
+		const a = newAtom(1)
+		const b = newAtom(2)
+		const c = newAtom(3)
+
+		const cb = jest.fn(constVoid)
+		render(<Test properties={[a, b, c]} onValue={cb} />)
+		expect(cb).toHaveBeenLastCalledWith(1, 2, 3)
+	})
+})

--- a/packages/react/src/use-properties.ts
+++ b/packages/react/src/use-properties.ts
@@ -1,0 +1,11 @@
+import { useMemo } from 'react'
+import { property, Property } from '@frp-ts/core'
+import { useProperty } from './use-property'
+
+export const useProperties = <Properties extends readonly Property<unknown>[]>(
+	...properties: readonly [...Properties]
+): property.MapPropertiesToValues<Properties> => {
+	const value$ = useMemo(() => property.combine(...properties, (...values) => values), properties)
+
+	return useProperty(value$)
+}

--- a/packages/react/src/use-properties.ts
+++ b/packages/react/src/use-properties.ts
@@ -3,9 +3,6 @@ import { property, Property } from '@frp-ts/core'
 import { useProperty } from './use-property'
 
 export const useProperties = <Properties extends readonly Property<unknown>[]>(
-	...properties: readonly [...Properties]
-): property.MapPropertiesToValues<Properties> => {
-	const value$ = useMemo(() => property.combine(...properties, (...values) => values), properties)
-
-	return useProperty(value$)
-}
+	...properties: Properties
+): property.MapPropertiesToValues<Properties> =>
+	useProperty(useMemo(() => property.combine(...properties, (...values) => values), properties))


### PR DESCRIPTION
If we use multiple properties:
```
const strings = useProperty(strings$)
const filteredStrings = useProperty(filteredStrings$)
```
Here we will have a problem with the diamond shape.

To solve this problem, we must combine them into one property.

To avoid doing this yourself, I suggest adding a `useProperties` hook.