### PR TITLE
fix(react): resolve bad `setState` in `usePropertyFromProps`

### DIFF
--- a/packages/react/src/use-property-from-props.spec.tsx
+++ b/packages/react/src/use-property-from-props.spec.tsx
@@ -3,6 +3,7 @@ import { usePropertyFromProps } from './use-property-from-props'
 import React, { useMemo } from 'react'
 import { render } from '@testing-library/react'
 import { constVoid } from '@frp-ts/utils'
+import { useProperty } from './use-property'
 
 interface TestProps<T> {
 	readonly value: T
@@ -28,5 +29,29 @@ describe('usePropertyFromProps', () => {
 		expect(cb).toHaveBeenCalledTimes(1)
 		tree.rerender(<Test value={2} onProperty={onProperty} />)
 		expect(cb).toHaveBeenCalledTimes(1)
+	})
+	it('renders without errors with child consumer', () => {
+		jest.spyOn(console, 'error').mockImplementation()
+
+		interface ConsumerProps {
+			property: Property<number>
+		}
+		const Consumer = (props: ConsumerProps) => {
+			const value = useProperty(props.property)
+			return <>{value}</>
+		}
+		interface ComponentProps {
+			enabled: boolean
+			value: number
+		}
+		const Component = (props: ComponentProps) => {
+			const property = usePropertyFromProps(props.value)
+			return <Consumer property={property} />
+		}
+
+		const tree = render(<Component enabled={true} value={1} />)
+		tree.rerender(<Component enabled={false} value={2} />)
+
+		expect(console.error).not.toBeCalled()
 	})
 })

--- a/packages/react/src/use-property-from-props.ts
+++ b/packages/react/src/use-property-from-props.ts
@@ -1,8 +1,8 @@
 import { newAtom, Property } from '@frp-ts/core'
-import { useEffect, useMemo } from 'react'
+import { useLayoutEffect, useMemo } from 'react'
 
 export const usePropertyFromProps = <Value>(value: Value): Property<Value> => {
 	const atom = useMemo(() => newAtom(value), [])
-	useEffect(() => atom.set(value), [value])
+	useLayoutEffect(() => atom.set(value), [value])
 	return atom
 }

--- a/packages/react/src/use-property-from-props.ts
+++ b/packages/react/src/use-property-from-props.ts
@@ -1,8 +1,8 @@
 import { newAtom, Property } from '@frp-ts/core'
-import { useState } from 'react'
+import { useEffect, useMemo } from 'react'
 
 export const usePropertyFromProps = <Value>(value: Value): Property<Value> => {
-	const [state] = useState(() => newAtom(value))
-	state.set(value)
-	return state
+	const atom = useMemo(() => newAtom(value), [])
+	useEffect(() => atom.set(value), [value])
+	return atom
 }


### PR DESCRIPTION
```
Warning: Cannot update a component (`%s`) while rendering a different component (`%s`).
To locate the bad setState() call inside `%s`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render 
%s", "Consumer", "Component", "Component"
```