### PR TITLE
fix: lensed atom distinct changes

### DIFF
--- a/packages/core/src/property.spec.ts
+++ b/packages/core/src/property.spec.ts
@@ -206,28 +206,6 @@ describe('combine', () => {
 		a.set(undefined)
 		expect(cb).toHaveBeenCalledTimes(1)
 	})
-	it('does not emit if combined property has not change value', () => {
-		const a = newAtom({ foo: 1, bar: '1' })
-		const foo = combine(a, (a) => a.foo)
-		const bar = combine(a, (a) => a.bar)
-
-		const fooObserver = {
-			next: jest.fn(),
-		}
-		const barObserver = {
-			next: jest.fn(),
-		}
-		foo.subscribe(fooObserver)
-		bar.subscribe(barObserver)
-
-		a.modify(p => ({ ...p, foo: 2 }))
-		expect(fooObserver.next).toHaveBeenCalledTimes(1)
-		expect(barObserver.next).toHaveBeenCalledTimes(0)
-
-		a.modify(p => ({ ...p, bar: '2' }))
-		expect(barObserver.next).toHaveBeenCalledTimes(1)
-		expect(fooObserver.next).toHaveBeenCalledTimes(1)
-	})
 })
 
 describe('flatten', () => {

--- a/packages/core/src/property.spec.ts
+++ b/packages/core/src/property.spec.ts
@@ -206,6 +206,28 @@ describe('combine', () => {
 		a.set(undefined)
 		expect(cb).toHaveBeenCalledTimes(1)
 	})
+	it('does not emit if combined property has not change value', () => {
+		const a = newAtom({ foo: 1, bar: '1' })
+		const foo = combine(a, (a) => a.foo)
+		const bar = combine(a, (a) => a.bar)
+
+		const fooObserver = {
+			next: jest.fn(),
+		}
+		const barObserver = {
+			next: jest.fn(),
+		}
+		foo.subscribe(fooObserver)
+		bar.subscribe(barObserver)
+
+		a.modify(p => ({ ...p, foo: 2 }))
+		expect(fooObserver.next).toHaveBeenCalledTimes(1)
+		expect(barObserver.next).toHaveBeenCalledTimes(0)
+
+		a.modify(p => ({ ...p, bar: '2' }))
+		expect(barObserver.next).toHaveBeenCalledTimes(1)
+		expect(fooObserver.next).toHaveBeenCalledTimes(1)
+	})
 })
 
 describe('flatten', () => {

--- a/packages/lens/src/lensed-atom.spec.ts
+++ b/packages/lens/src/lensed-atom.spec.ts
@@ -109,4 +109,25 @@ describe('view', () => {
 		expect(ao.next).toHaveBeenCalledTimes(1)
 		expect(bo.next).toHaveBeenCalledTimes(1)
 	})
+	it('distinct changes', () => {
+		const a = newLensedAtom({ foo: 0, bar: 'bar' })
+		const foo = a.view(prop('foo'))
+		const bar = a.view(prop('bar'))
+		const fooObserver = {
+			next: jest.fn(),
+		}
+		const barObserver = {
+			next: jest.fn(),
+		}
+		foo.subscribe(fooObserver)
+		bar.subscribe(barObserver)
+
+		foo.set(2)
+		expect(fooObserver.next).toHaveBeenCalledTimes(1)
+		expect(barObserver.next).toHaveBeenCalledTimes(0)
+
+		bar.set('baz')
+		expect(barObserver.next).toHaveBeenCalledTimes(1)
+		expect(fooObserver.next).toHaveBeenCalledTimes(1)
+	})
 })

--- a/packages/lens/src/lensed-atom.spec.ts
+++ b/packages/lens/src/lensed-atom.spec.ts
@@ -121,6 +121,9 @@ describe('view', () => {
 		}
 		foo.subscribe(fooObserver)
 		bar.subscribe(barObserver)
+		// imitate consumer to warm up the cache
+		foo.get()
+		bar.get()
 
 		foo.set(2)
 		expect(fooObserver.next).toHaveBeenCalledTimes(1)

--- a/packages/lens/src/lensed-atom.ts
+++ b/packages/lens/src/lensed-atom.ts
@@ -1,4 +1,4 @@
-import {Atom, combine, newAtom, newProperty} from '@frp-ts/core'
+import { Atom, combine, newAtom } from '@frp-ts/core'
 
 export interface Lens<S, A> {
 	readonly get: (s: S) => A


### PR DESCRIPTION
Currently `LensedAtom` emits changes from the parent `Atom`

To resolve it, I'm adding distinct changes to the lense via `property#combine`