### PR TITLE
fix(core): combine lost notification of middle node

### DIFF
--- a/packages/core/src/property.spec.ts
+++ b/packages/core/src/property.spec.ts
@@ -4,7 +4,7 @@ import { never, newObservable } from './observable'
 import { constVoid } from '@frp-ts/utils'
 import { combine, flatten, fromObservable, newProperty, Property, scan, tap } from './property'
 import { from, Observable, Subject } from 'rxjs'
-import {action, mergeMany, multicast, newEmitter} from './emitter'
+import { action, newEmitter } from './emitter'
 import { attachSubscription } from '@frp-ts/test-utils'
 import { now } from './clock'
 
@@ -44,11 +44,11 @@ describe('combine', () => {
 		const cb1 = jest.fn()
 		// subscribe and read value
 		c.subscribe({
-			next: () => c.get()
+			next: () => c.get(),
 		})
 
 		b.subscribe({
-			next: cb1
+			next: cb1,
 		})
 
 		a.set(2)


### PR DESCRIPTION
We lose change notifications if we combine `a` and its derivative `b` into `c`.
```ts
const a = newAtom(1)
const b = combine(a, (a) => [a])

const c = combine(a, b, (v1, v2) => [v1, v2])
```

And then read `c` value immediately in `next`, we warm up the cache of the `b`.
```ts
const cb1 = jest.fn()
// subscribe and read value instantly
c.subscribe({
	next: () => c.get(),
})

b.subscribe({
	next: cb1,
})
```

And then emit a new value in `a`, the subscriber `b` will not receive a notification.
```ts
a.set(2)
```