### PR TITLE
chore: move @frp-ts/test-utils to dev dependencies

### DIFF
--- a/packages/fp-ts/package.json
+++ b/packages/fp-ts/package.json
@@ -22,6 +22,7 @@
     "@frp-ts/utils": "^1.0.0-beta.0"
   },
   "devDependencies": {
+    "@frp-ts/test-utils": "^1.0.0-beta.0",
     "fp-ts": "^2.11.5",
     "rimraf": "^3.0.2",
     "rxjs": "^7.4.0",

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -25,6 +25,7 @@
     "@frp-ts/core": "^1.0.0-beta.0"
   },
   "devDependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@frp-ts/test-utils": "^1.0.0-beta.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,6 +22,7 @@
     "@frp-ts/utils": "^1.0.0-beta.0"
   },
   "devDependencies": {
+    "@frp-ts/test-utils": "^1.0.0-beta.0",
     "@testing-library/react": "^12.1.2",
     "@types/react": ">=16.0.0",
     "@types/react-dom": ">=16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
   packages/fp-ts:
     specifiers:
       '@frp-ts/core': ^1.0.0-beta.0
+      '@frp-ts/test-utils': ^1.0.0-beta.0
       '@frp-ts/utils': ^1.0.0-beta.0
       fp-ts: ^2.11.5
       rimraf: ^3.0.2
@@ -107,6 +108,7 @@ importers:
       '@frp-ts/core': link:../core
       '@frp-ts/utils': link:../utils
     devDependencies:
+      '@frp-ts/test-utils': link:../test-utils
       fp-ts: 2.11.5
       rimraf: 3.0.2
       rxjs: 7.5.1
@@ -116,15 +118,18 @@ importers:
   packages/lens:
     specifiers:
       '@frp-ts/core': ^1.0.0-beta.0
+      '@frp-ts/test-utils': ^1.0.0-beta.0
       tslib: ^2.1.0
     dependencies:
       '@frp-ts/core': link:../core
     devDependencies:
+      '@frp-ts/test-utils': link:../test-utils
       tslib: 2.3.1
 
   packages/react:
     specifiers:
       '@frp-ts/core': ^1.0.0-beta.0
+      '@frp-ts/test-utils': ^1.0.0-beta.0
       '@frp-ts/utils': ^1.0.0-beta.0
       '@testing-library/react': ^12.1.2
       '@types/react': '>=16.0.0'
@@ -136,6 +141,7 @@ importers:
       '@frp-ts/core': link:../core
       '@frp-ts/utils': link:../utils
     devDependencies:
+      '@frp-ts/test-utils': link:../test-utils
       '@testing-library/react': 12.1.2_sfoxds7t5ydpegc3knd667wn6m
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11


### PR DESCRIPTION
Hi, last build of @frp-ts/react@1.0.0-beta.0 has next peerDeps:
```
"peerDependencies": {
    "@types/react": ">=16.0.0",
    "react": ">=16.0.0",
    "tslib": "^2.3.1",
    "@frp-ts/test-utils": "1.0.0-beta.0"
  },
```
where `@frp-ts/test-utils` is a private, non publisable library.

So when I tired to install it i got next error:
![Screenshot 2022-07-25 at 17 48 59](https://user-images.githubusercontent.com/18456914/180760178-46ce1c38-5129-4289-a259-6375be2e0321.png)

I take a look for other packages and add changes to packages where NX add this libs as a peer.