### PR TITLE
feat(react): Use sync external store

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,16 +25,16 @@
   "devDependencies": {
     "@frp-ts/test-utils": "^1.0.0-beta.2",
     "@testing-library/react": "^12.1.2",
-    "@types/react": ">=16.0.0",
-    "@types/react-dom": ">=16.0.0",
+    "@types/react": ">=16.8.0",
+    "@types/react-dom": ">=16.8.0",
     "@types/use-sync-external-store": "^0.0.3",
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.0.0",
-    "react": ">=16.0.0",
+    "@types/react": ">=16.8.0",
+    "react": ">=16.8.0",
     "tslib": "^2.3.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,6 +18,7 @@
     "access": "public"
   },
   "dependencies": {
+    "use-sync-external-store": "^1.2.0",
     "@frp-ts/core": "^1.0.0-beta.2",
     "@frp-ts/utils": "^1.0.0-beta.2"
   },
@@ -26,6 +27,7 @@
     "@testing-library/react": "^12.1.2",
     "@types/react": ">=16.0.0",
     "@types/react-dom": ">=16.0.0",
+    "@types/use-sync-external-store": "^0.0.3",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0",
     "tslib": "^2.3.1"

--- a/packages/react/src/use-observable.ts
+++ b/packages/react/src/use-observable.ts
@@ -8,9 +8,11 @@ interface Ref<Value> {
 }
 
 export function useObservable<Value>(source: Observable<Value>, initial: Value): Value {
-	// eslint-disable-next-line no-restricted-syntax
-	const ref = useRef<Ref<Value>>(undefined as unknown as Ref<Value>)
-	if (ref.current === undefined || ref.current.source !== source) {
+	const ref = useRef<Ref<Value>>({
+		source,
+		value: initial,
+	})
+	if (ref.current.source !== source) {
 		ref.current = {
 			source,
 			value: initial,

--- a/packages/react/src/use-observable.ts
+++ b/packages/react/src/use-observable.ts
@@ -1,19 +1,36 @@
 import { Observable } from '@frp-ts/core'
-import { useEffect, useState } from 'react'
+import { useRef, useCallback } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
+
+interface Ref<Value> {
+	source: Observable<Value>
+	value: Value
+}
 
 export function useObservable<Value>(source: Observable<Value>, initial: Value): Value {
-	const [state, setState] = useState(() => initial)
-
-	useEffect(() => {
-		const subscription = source.subscribe({
-			next: (value) => {
-				setState(() => value)
-			},
-		})
-		return () => {
-			subscription.unsubscribe()
+	// eslint-disable-next-line no-restricted-syntax
+	const ref = useRef<Ref<Value>>(undefined as unknown as Ref<Value>)
+	if (ref.current === undefined || ref.current.source !== source) {
+		ref.current = {
+			source,
+			value: initial,
 		}
-	}, [source])
+	}
 
-	return state
+	const get = useCallback(() => ref.current.value, [])
+	const subscribe = useCallback(
+		(next: () => void) => {
+			const subscription = source.subscribe({
+				next: (value) => {
+					ref.current.value = value
+					next()
+				},
+			})
+
+			return subscription.unsubscribe
+		},
+		[source],
+	)
+
+	return useSyncExternalStore(subscribe, get)
 }

--- a/packages/react/src/use-property.spec.tsx
+++ b/packages/react/src/use-property.spec.tsx
@@ -54,14 +54,12 @@ describe('useProperty', () => {
 		expect(cb).not.toHaveBeenCalled()
 	})
 	it('triggers rerender even if newValue is emitted on the same tick', () => {
-		let counter = 0
-		const e = newEmitter()
-		const p: Property<number> = newProperty(() => counter++, e.subscribe)
+		const a = newAtom(0)
 		const cb = jest.fn(constVoid)
-		render(<Test property={p} onValue={cb} />)
+		render(<Test property={a} onValue={cb} />)
 		cb.mockClear()
-		act(() => e.next(0))
-		act(() => e.next(0))
+		act(() => a.set(1))
+		act(() => a.set(1))
 		expect(cb).toHaveBeenCalledTimes(1)
 	})
 	it('unsubscribes from property on unmount', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,17 +134,21 @@ importers:
       '@testing-library/react': ^12.1.2
       '@types/react': '>=16.0.0'
       '@types/react-dom': '>=16.0.0'
+      '@types/use-sync-external-store': ^0.0.3
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
       tslib: ^2.1.0
+      use-sync-external-store: ^1.2.0
     dependencies:
       '@frp-ts/core': link:../core
       '@frp-ts/utils': link:../utils
+      use-sync-external-store: 1.2.0_react@17.0.2
     devDependencies:
       '@frp-ts/test-utils': link:../test-utils
       '@testing-library/react': 12.1.2_sfoxds7t5ydpegc3knd667wn6m
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
+      '@types/use-sync-external-store': 0.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.3.1
@@ -2496,6 +2500,10 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/use-sync-external-store/0.0.3:
+    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
     dev: true
 
   /@types/yargs-parser/20.2.1:
@@ -5786,7 +5794,6 @@ packages:
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -6095,7 +6102,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -6716,7 +6722,6 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -7232,7 +7237,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /read-cmd-shim/2.0.0:
     resolution: {integrity: sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==}
@@ -8384,6 +8388,14 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
+
+  /use-sync-external-store/1.2.0_react@17.0.2:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,11 +132,11 @@ importers:
       '@frp-ts/test-utils': ^1.0.0-beta.2
       '@frp-ts/utils': ^1.0.0-beta.2
       '@testing-library/react': ^12.1.2
-      '@types/react': '>=16.0.0'
-      '@types/react-dom': '>=16.0.0'
+      '@types/react': '>=16.8.0'
+      '@types/react-dom': '>=16.8.0'
       '@types/use-sync-external-store': ^0.0.3
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
       tslib: ^2.1.0
       use-sync-external-store: ^1.2.0
     dependencies:
@@ -2232,6 +2232,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2241,6 +2242,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -2250,6 +2252,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2259,6 +2262,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -6720,7 +6724,7 @@ packages:
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   /object-inspect/1.12.0:


### PR DESCRIPTION
In React 18, concurrent rendering makes has a glitch issue, coz React pauses during rendering. Between these pauses, updates can pull in the changes related to the data being used to render. It causes the UI to show two different values for the same data.

To solve this issue,`useSyncExternalStore` was introduced in React 18 for external stores.