### PR TITLE
Fix infinite loop when the action was called during notifying by another action

### DIFF
--- a/packages/core/src/atom.spec.ts
+++ b/packages/core/src/atom.spec.ts
@@ -34,6 +34,14 @@ describe('atom', () => {
 		expect(cb).toHaveBeenCalledTimes(1)
 		expect(cb).toHaveBeenLastCalledWith(4)
 	})
+	it('does not enter an infinite loop if the action was called during notifying by another action', () => {
+		const a = newAtom(0)
+		const fn = jest.fn()
+		const cb = () => action(fn)
+		a.subscribe({ next: cb })
+		action(() => a.set(1))
+		expect(fn).toHaveBeenCalledTimes(1)
+	})
 	it('skips duplicates', () => {
 		const { set, subscribe } = newAtom(0)
 		const f = jest.fn()

--- a/packages/core/src/emitter.ts
+++ b/packages/core/src/emitter.ts
@@ -10,10 +10,10 @@ export const action = (f: () => void): void => {
 	isLocked = false
 	if (lastTime !== undefined) {
 		for (const listener of Array.from(lockedListeners)) {
+			lockedListeners.delete(listener)
 			listener(lastTime)
 		}
 		lastTime = undefined
-		lockedListeners.clear()
 	}
 }
 


### PR DESCRIPTION
@raveclassic Hi

Infinite loop bugfix when I call action during notifying under another action

```typescript
const a = newAtom(0)
const cb = () => action(() => {})
a.subscribe({ next: cb })
action(() => a.set(1))
```