### PR TITLE
usePropertyFromProps inconsistency 

### DIFF
--- a/packages/react/src/use-property-from-props.spec.tsx
+++ b/packages/react/src/use-property-from-props.spec.tsx
@@ -30,6 +30,24 @@ describe('usePropertyFromProps', () => {
 		tree.rerender(<Test value={2} onProperty={onProperty} />)
 		expect(cb).toHaveBeenCalledTimes(1)
 	})
+	it('syncs property value with the value from props during render', () => {
+		interface ComponentProps<T> {
+			readonly value: T
+			readonly onRender: (valueFromProps: T, property: Property<T>) => void
+		}
+
+		function Component<T>(props: ComponentProps<T>) {
+			const property = usePropertyFromProps(props.value)
+			props.onRender(props.value, property)
+			return <></>
+		}
+
+		const onRender = (valueFromProps: number, property: Property<number>) =>
+			expect(valueFromProps).toBe(property.get())
+		const tree = render(<Component value={1} onRender={onRender} />)
+		tree.rerender(<Component value={2} onRender={onRender} />)
+		tree.rerender(<Component value={3} onRender={onRender} />)
+	})
 	it('renders without errors with child consumer', () => {
 		jest.spyOn(console, 'error').mockImplementation()
 

--- a/packages/react/src/use-property-from-props.ts
+++ b/packages/react/src/use-property-from-props.ts
@@ -1,8 +1,19 @@
-import { newAtom, Property } from '@frp-ts/core'
-import { useEffect, useState } from 'react'
+import { newEmitter, newProperty, Property, now } from '@frp-ts/core'
+import { useEffect, useMemo, useRef } from 'react'
 
 export const usePropertyFromProps = <Value>(value: Value): Property<Value> => {
-	const [atom] = useState(() => newAtom(value))
-	useEffect(() => atom.set(value), [value])
-	return atom
+	const didMount = useRef(false)
+	const emitter = useRef(newEmitter())
+	const valueRef = useRef(value)
+	valueRef.current = value
+
+	useEffect(() => {
+		if (didMount.current) {
+			emitter.current.next(now())
+		} else {
+			didMount.current = true
+		}
+	}, [value])
+
+	return useMemo(() => newProperty(() => valueRef.current, emitter.current.subscribe), [])
 }


### PR DESCRIPTION
Hi @raveclassic!

There is a problem with `usePropertyFromProps` - the atom changes after the render and at the moment of the react props change `value !== property.get()`: 

```typescript
const Component = ({ value }) => {
  const property = usePropertyFromProps(value)
  
  property.get() === value // false at the moment of the props change 
}
```